### PR TITLE
Only write a maximum of MTU bytes at a time, and write asynchronously

### DIFF
--- a/src/osx/BTSerialPortBinding.mm
+++ b/src/osx/BTSerialPortBinding.mm
@@ -99,7 +99,7 @@ void BTSerialPortBinding::EIO_Write(uv_work_t *req) {
     BluetoothWorker *worker = [BluetoothWorker getInstance];
     NSString *address = [NSString stringWithCString:data->address encoding:NSASCIIStringEncoding];
 
-    if ([worker writeSync: data->bufferData length: data->bufferLength toDevice: address] != kIOReturnSuccess) {
+    if ([worker writeAsync: data->bufferData length: data->bufferLength toDevice: address] != kIOReturnSuccess) {
         sprintf(data->errorString, "Write was unsuccessful");
     } else {
         data->result = data->bufferLength;

--- a/src/osx/BluetoothWorker.h
+++ b/src/osx/BluetoothWorker.h
@@ -42,7 +42,7 @@ struct device_info_t {
 + (id)getInstance;
 - (void) disconnectFromDevice: (NSString *) address;
 - (IOReturn)connectDevice: (NSString *) address onChannel: (int) channel withPipe: (pipe_t *)pipe;
-- (IOReturn)writeSync:(void *)data length:(UInt16)length toDevice: (NSString *)address;
+- (IOReturn)writeAsync:(void *)data length:(UInt16)length toDevice: (NSString *)address;
 - (void) inquireWithPipe: (pipe_t *)pipe;
 - (int) getRFCOMMChannelID: (NSString *) address;
 


### PR DESCRIPTION
Addresses issue #23 and issue #24

Discussion needed to address async writes on #24 since it makes the callback fire deceptively early. Please see comments in respective commits.
