### PR TITLE
Fix buffer overflow on close() in mac osx. 

### DIFF
--- a/src/osx/BTSerialPortBinding.mm
+++ b/src/osx/BTSerialPortBinding.mm
@@ -329,8 +329,8 @@ Handle<Value> BTSerialPortBinding::Close(const Arguments& args) {
 
     //TODO should be a better way to do this...
     String::Utf8Value addressParameter(args[0]);
-    char addressArray[16];
-    strcpy(addressArray, *addressParameter);
+    char addressArray[32];
+    strncpy(addressArray, *addressParameter, 32);
     NSString *address = [NSString stringWithCString:addressArray encoding:NSASCIIStringEncoding];
 
     BluetoothWorker *worker = [BluetoothWorker getInstance];


### PR DESCRIPTION
Ran into a crash when trying to call .close() on a serial port. Turned out on osx the address buffer size was only 16 bytes, but addresses are 18 bytes e.g "00-04-3e-31-5b-58".

Extended buffer to fit address string and used strncpy to be a little safer.
