### PR TITLE
Fixes #28 by preventing Buffer being invalidated by GC during a read

### DIFF
--- a/src/linux/BTSerialPortBinding.cc
+++ b/src/linux/BTSerialPortBinding.cc
@@ -174,6 +174,8 @@ void BTSerialPortBinding::EIO_Read(uv_work_t *req) {
 }
     
 void BTSerialPortBinding::EIO_AfterRead(uv_work_t *req) {
+    HandleScope scope;
+
     read_baton_t *baton = static_cast<read_baton_t *>(req->data);
     
     TryCatch try_catch;
@@ -184,15 +186,14 @@ void BTSerialPortBinding::EIO_AfterRead(uv_work_t *req) {
         argv[0] = Exception::Error(String::New("Error reading from connection"));
         argv[1] = Undefined();
     } else {
-        Buffer *buffer = Buffer::New(baton->size);
-        memcpy(Buffer::Data(buffer), baton->result, baton->size);
         Local<Object> globalObj = Context::GetCurrent()->Global();
         Local<Function> bufferConstructor = Local<Function>::Cast(globalObj->Get(String::New("Buffer")));
-        Handle<Value> constructorArgs[3] = { buffer->handle_, Integer::New(baton->size), Integer::New(0) };
-        Local<Object> resultBuffer = bufferConstructor->NewInstance(3, constructorArgs);
+        Handle<Value> constructorArgs[1] = { Integer::New(baton->size) };
+        Local<Object> resultBuffer = bufferConstructor->NewInstance(1, constructorArgs);
+        memcpy(Buffer::Data(resultBuffer), baton->result, baton->size);
 
         argv[0] = Undefined();
-        argv[1] = resultBuffer;
+        argv[1] = scope.Close(resultBuffer);
     }
 
     baton->cb->Call(Context::GetCurrent()->Global(), 2, argv);

--- a/src/windows/BTSerialPortBinding.cc
+++ b/src/windows/BTSerialPortBinding.cc
@@ -168,15 +168,14 @@ void BTSerialPortBinding::EIO_AfterRead(uv_work_t *req) {
         argv[0] = Exception::Error(String::New("Error reading from connection"));
         argv[1] = Undefined();
     } else {
-        Buffer *buffer = Buffer::New(baton->size);
-        memcpy_s(Buffer::Data(buffer), baton->size, baton->result, baton->size);
         Local<Object> globalObj = Context::GetCurrent()->Global();
         Local<Function> bufferConstructor = Local<Function>::Cast(globalObj->Get(String::New("Buffer")));
-        Handle<Value> constructorArgs[3] = { buffer->handle_, Integer::New(baton->size), Integer::New(0) };
-        Local<Object> resultBuffer = bufferConstructor->NewInstance(3, constructorArgs);
+        Handle<Value> constructorArgs[1] = { Integer::New(baton->size) };
+        Local<Object> resultBuffer = bufferConstructor->NewInstance(1, constructorArgs);
+        memcpy_s(Buffer::Data(resultBuffer), baton->size, baton->result, baton->size);
 
         argv[0] = Undefined();
-        argv[1] = resultBuffer;
+        argv[1] = scope.Close(resultBuffer);
     }
 
     baton->cb->Call(Context::GetCurrent()->Global(), 2, argv);


### PR DESCRIPTION
This should prevent the Buffer allocated in EIO_AfterRead from getting invalidated by the GC, which caused a segfault when attempting to use the invalidated handle.

Related to joyent/node#5864
