### PR TITLE
Add support for listing paired devices

### DIFF
--- a/experiments/paired-devices-test.js
+++ b/experiments/paired-devices-test.js
@@ -1,0 +1,14 @@
+(function() {
+    "use strict";
+
+    var util = require('util');
+    var DeviceINQ = require("../lib/device-inquiry.js").DeviceINQ;
+    var BluetoothSerialPort = require("../lib/bluetooth-serial-port.js").BluetoothSerialPort;
+    var serial = new BluetoothSerialPort();
+
+    serial.listPairedDevices(function(pairedDevices) {
+        pairedDevices.forEach(function(device) {
+            console.log(device);
+        });
+    })
+})();

--- a/lib/bluetooth-serial-port.js
+++ b/lib/bluetooth-serial-port.js
@@ -40,6 +40,10 @@
     util.inherits(BluetoothSerialPort, EventEmitter);
     exports.BluetoothSerialPort = BluetoothSerialPort;
 
+    BluetoothSerialPort.prototype.listPairedDevices = function(callback) {
+        this.inq.listPairedDevices(callback);
+    };
+
     BluetoothSerialPort.prototype.inquire = function() {
         this.inq.inquire();
     };

--- a/src/DeviceINQ.h
+++ b/src/DeviceINQ.h
@@ -48,6 +48,7 @@ class DeviceINQ : public node::ObjectWrap {
         static v8::Handle<v8::Value> New(const v8::Arguments& args);
         static v8::Handle<v8::Value> Inquire(const v8::Arguments& args);
         static v8::Handle<v8::Value> SdpSearch(const v8::Arguments& args);
+        static v8::Handle<v8::Value> ListPairedDevices(const v8::Arguments& args);
 };
 
 #endif

--- a/src/linux/DeviceINQ.cc
+++ b/src/linux/DeviceINQ.cc
@@ -153,6 +153,8 @@ void DeviceINQ::Init(Handle<Object> target) {
     
     NODE_SET_PROTOTYPE_METHOD(t, "inquire", Inquire);
     NODE_SET_PROTOTYPE_METHOD(t, "findSerialPortChannel", SdpSearch);
+    NODE_SET_PROTOTYPE_METHOD(t, "listPairedDevices", ListPairedDevices);
+    target->Set(String::NewSymbol("DeviceINQ"), t->GetFunction());
     target->Set(String::NewSymbol("DeviceINQ"), t->GetFunction());
     target->Set(String::NewSymbol("DeviceINQ"), t->GetFunction());
 }
@@ -272,4 +274,37 @@ Handle<Value> DeviceINQ::SdpSearch(const Arguments& args) {
     uv_queue_work(uv_default_loop(), &baton->request, EIO_SdpSearch, (uv_after_work_cb)EIO_AfterSdpSearch);
 
     return Undefined();
+}
+
+Handle<Value> DeviceINQ::ListPairedDevices(const Arguments& args) {
+    HandleScope scope;
+
+    const char *usage = "usage: listPairedDevices(callback)";
+    if (args.Length() != 1) {
+        return scope.Close(ThrowException(Exception::Error(String::New(usage))));
+    }
+
+    if(!args[0]->IsFunction()) {
+        return scope.Close(ThrowException(Exception::TypeError(String::New("First argument must be a function"))));
+    }
+    Local<Function> cb = Local<Function>::Cast(args[0]);
+
+    Local<Array> resultArray = Array::New(0);
+
+    // TODO: build an array of objects representing a paired device:
+    // ex: {
+    //   name: 'MyBluetoothDeviceName',
+    //   address: '12-34-56-78-90',
+    //   services: [
+    //     { name: 'SPP', channel: 1 },
+    //     { name: 'iAP', channel: 2 }
+    //   ]
+    // }
+
+    Local<Value> argv[1] = {
+        resultArray
+    };
+    cb->Call(Context::GetCurrent()->Global(), 1, argv);
+
+    return scope.Close(Undefined());
 }

--- a/src/windows/DeviceINQ.cc
+++ b/src/windows/DeviceINQ.cc
@@ -120,6 +120,8 @@ void DeviceINQ::Init(Handle<Object> target) {
     
     NODE_SET_PROTOTYPE_METHOD(t, "inquire", Inquire);
     NODE_SET_PROTOTYPE_METHOD(t, "findSerialPortChannel", SdpSearch);
+    NODE_SET_PROTOTYPE_METHOD(t, "listPairedDevices", ListPairedDevices);
+    target->Set(String::NewSymbol("DeviceINQ"), t->GetFunction());
     target->Set(String::NewSymbol("DeviceINQ"), t->GetFunction());
     target->Set(String::NewSymbol("DeviceINQ"), t->GetFunction());
 }
@@ -277,4 +279,37 @@ Handle<Value> DeviceINQ::SdpSearch(const Arguments& args) {
     uv_queue_work(uv_default_loop(), &baton->request, EIO_SdpSearch, (uv_after_work_cb)EIO_AfterSdpSearch);
 
     return Undefined();
+}
+
+Handle<Value> DeviceINQ::ListPairedDevices(const Arguments& args) {
+    HandleScope scope;
+
+    const char *usage = "usage: listPairedDevices(callback)";
+    if (args.Length() != 1) {
+        return scope.Close(ThrowException(Exception::Error(String::New(usage))));
+    }
+
+    if(!args[0]->IsFunction()) {
+        return scope.Close(ThrowException(Exception::TypeError(String::New("First argument must be a function"))));
+    }
+    Local<Function> cb = Local<Function>::Cast(args[0]);
+
+    Local<Array> resultArray = Array::New(0);
+
+    // TODO: build an array of objects representing a paired device:
+    // ex: {
+    //   name: 'MyBluetoothDeviceName',
+    //   address: '12-34-56-78-90',
+    //   services: [
+    //     { name: 'SPP', channel: 1 },
+    //     { name: 'iAP', channel: 2 }
+    //   ]
+    // }
+
+    Local<Value> argv[1] = {
+        resultArray
+    };
+    cb->Call(Context::GetCurrent()->Global(), 1, argv);
+
+    return scope.Close(Undefined());
 }


### PR DESCRIPTION
This add support for listing already paired devices:

```
var BluetoothSerialPort = require("bluetooth-serial-port").BluetoothSerialPort;
var serial = new BluetoothSerialPort();

serial.listPairedDevices(function(pairedDevices) {
    pairedDevices.forEach(function(device) {
        console.log(device);
    });
});
```

Will print something like:

```
{ name: 'Moss-CMB',
  address: '00-04-3e-31-c9-d6',
  services: 
   [ { channel: 1, name: 'AMP-SPP' },
     { channel: 2, name: 'AMP-iAP' } ] }
{ name: 'Phi',
  address: '58-b0-35-98-c8-92',
  services: 
   [ { channel: 4, name: 'Headset Audio Gateway' },
     { channel: 4, name: 'Network Access Point Service' },
     { channel: 4, name: 'A2DP Audio Source' },
     { channel: 4, name: 'AVRCP Target' },
     { channel: 4, name: 'Apple Macintosh Attributes' },
     { channel: 10, name: 'OBEX Object Push' },
     { channel: 3, name: 'Bluetooth-Incoming-Port' },
     { channel: 15, name: 'OBEX File Transfer' },
     { channel: 2, name: 'Hands Free Audio Gateway' },
     { channel: 2, name: 'Group Ad-hoc Network Service' } ] }
{ name: 'MINIJAMBOX by Jawbone',
  address: 'e0-d1-e6-05-6b-3b',
  services: 
   [ { channel: 2, name: undefined },
     { channel: 3, name: 'Headset' },
     { channel: 3, name: undefined },
     { channel: 3, name: undefined },
     { channel: 1, name: 'SPP Dev' },
     { channel: 1, name: undefined },
     { channel: 2, name: 'Hands-Free unit' } ] }
{ name: 'Donald Ness\'s Trackpad',
  address: 'c8-bc-c8-fc-21-de',
  services: 
   [ { channel: 2, name: 'Apple Wireless Trackpad' },
     { channel: 2, name: undefined } ] }
```

So far, only support for OS X has been added. Linux and Windows are stubbed out, and return an empty array.

On OS X, this also makes it possible to find devices which already have a baseband connection established  -- i.e. a device is connected to another app, or has auto-reconnected on its own to the host. Currently, connected devices do not appear in an inquiry, but can be listed from the paired devices list.

Also, connecting directly from the paired devices list is much quicker than performing a full discovery / inquiry.
