### PR TITLE
Basic ListPairedDevices for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This node module lets you communicate over Bluetooth serial port with devices us
 
 * Needs Bluetooth development packages to build
 
-`apt-get install libbluetooth-dev`
+`apt-get install build-essential libbluetooth-dev`
 
 ## Pre-request on OS X
 


### PR DESCRIPTION
Adds ListPairedDevices for Windows, is virtually instantaneous and
compared to inquiry.  The code could be greatly improved. The SPP
channel is currently being hard coded to 1, ideally this would be
populated using SDP. There is code duplication with Inquiry().