### PR TITLE
Add cross-platform continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
-language: node_js
-node_js:
-  - "0.12"
-  - "0.11"
-  - "0.10"
-  - "iojs"
+language: ruby # node_js is not supported on osx
+env: # we don't care of rvm, we only want to have the right number fo jobs
+  - NODE_VERSION=0.10
+  - NODE_VERSION=0.11
+  - NODE_VERSION=0.12
+  - NODE_VERSION=iojs
 os:
   - linux
   - osx
@@ -12,6 +12,7 @@ before_install:
   - ./test/before_install.sh
 
 script:
+  - export PATH=$PATH:./node_modules/.bin
   - node-gyp configure
   - node-gyp build
   - node ./test/index.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,10 @@ node_js:
 before_install:
   - apt-get install libbluetooth-dev
   - npm install node-gyp
-script: "./node_modules/.bin/node-gyp configure && ./node_modules/.bin/node-gyp build"
+  - export PATH=$PATH:./node_modules/.bin
+
+script:
+  - node-gyp configure
+  - node-gyp build
+  - node ./test/index.js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ node_js:
   - "0.11"
   - "0.10"
   - "iojs"
+os:
+  - linux
+  - osx
 
 before_install:
-  - sudo apt-get install libbluetooth-dev -y
-  - npm install node-gyp
-  - export PATH=$PATH:./node_modules/.bin
+  - ./test/before_install.sh
 
 script:
   - node-gyp configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "iojs"
 
 before_install:
-  - apt-get install libbluetooth-dev
+  - sudo apt-get install libbluetooth-dev -y
   - npm install node-gyp
   - export PATH=$PATH:./node_modules/.bin
 
@@ -14,4 +14,5 @@ script:
   - node-gyp configure
   - node-gyp build
   - node ./test/index.js
+
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: node_js
+node_js:
+  - "0.12"
+  - "0.11"
+  - "0.10"
+  - "iojs"
+
+before_install:
+  - apt-get install libbluetooth-dev
+  - npm install node-gyp
+script: "./node_modules/.bin/node-gyp configure && ./node_modules/.bin/node-gyp build"
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+environment:
+  matrix:
+  # node.js
+  - nodejs_version: "0.10"
+  - nodejs_version: "0.11"
+  - nodejs_version: "0.12"
+  # io.js
+  - nodejs_version: "1.0"
+  - nodejs_version: "1.1"
+  - nodejs_version: "1.2"
+
+platform:
+  - x86
+  - x64
+
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install node-gyp
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  - node --version
+  - npm --version
+  # run tests
+  - node_modules\.bin\node-gyp configure
+  - node_modules\.bin\node-gyp build
+  - node test\index.js
+
+# Don't actually build.
+build: off

--- a/test/before_install.sh
+++ b/test/before_install.sh
@@ -1,0 +1,26 @@
+
+if [ x$CI -ne "xtrue" ]
+then
+    echo "This script is made to run under continuous integration"
+    exit 1
+fi
+
+## Platform-specific settings
+case $TRAVIS_OS_NAME in
+    "osx")
+        echo "== OSX build detected"
+        ;;
+    "linux")
+        echo "== LINUX build detected"
+        sudo apt-get install -y libbluetooth-dev
+        ;;
+    *)
+        echo "== non-LINUX non-OSX build detected"
+        echo "ERRROR ! The build process is not programmed for other platforms than travis linux and osx. Please contact the maintainers of the package."
+        exit 1
+        ;;
+esac
+
+## Common settings
+npm install node-gyp
+export PATH=$PATH:./node_modules/.bin

--- a/test/before_install.sh
+++ b/test/before_install.sh
@@ -9,10 +9,14 @@ fi
 case $TRAVIS_OS_NAME in
     "osx")
         echo "== OSX build detected"
+        brew install nvm
+        source $(brew --prefix nvm)/nvm.sh
+        export NVM_DIR=~/.nvm
         ;;
     "linux")
         echo "== LINUX build detected"
         sudo apt-get install -y libbluetooth-dev
+        npm install -g nvm
         ;;
     *)
         echo "== non-LINUX non-OSX build detected"
@@ -22,5 +26,7 @@ case $TRAVIS_OS_NAME in
 esac
 
 ## Common settings
+nvm install $NODE_VERSION
+nvm use $NODE_VERSION
 npm install node-gyp
-export PATH=$PATH:./node_modules/.bin
+npm install

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,13 @@
+var bt = require('bluetooth-serial-port');
+var Bt = new bt.BluetoothSerialPort();
+
+[
+    'inquire', 'findSerialPortChannel', 'connect', 'write', 'on', 'close'
+].forEach(function(fun) {
+    if (typeof Bt[fun] !== 'function')
+        throw new Error("Assert failed: " + fun +
+                        "should be a function but is " + (typeof Bt[fun]));
+});
+
+process.exit(0);
+

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-var bt = require('bluetooth-serial-port');
+var bt = require('../lib/bluetooth-serial-port.js');
 var Bt = new bt.BluetoothSerialPort();
 
 [


### PR DESCRIPTION
This is a WIP.
I pushed the PR mainly because it's easier to check the status-pill. (also because it's still open to discussion)

I plan to have the following build matrix:
- node.js 0.10.last, 0.11.last, 0.12.last
- iojs last

Against the following platforms:
- ubuntu LTS
- mac osx 10.9.5
- windows

The build step is the following:
- boot the fresh CI environment
- run a `node-gyp configure && node-gyp build`
- load a dummy `test.js` which require `bluetooth-serial-port` and `exit 0` if successfully loaded
- the test pass if a `BluetoothSerialPort.node` has been generated and if `test.js` returns 0

TODO:
- [x] dummy test script
- [x] ubuntu LTS builds via travis-ci
- [x] osx 10.9.5 builds via travis-ci if they are nice enough (http://docs.travis-ci.com/user/multi-os/)
  - [x] asked to travis [ref](https://github.com/eelcocramer/node-bluetooth-serial-port/pull/58#issuecomment-74565042)
  - [x] waiting the travis reply for osx activation
  - [x] need nvm on the osx builds, waiting travis support for a solution
  - [x] implement node installation platform-specific
- [ ] windows builds via app-veyor (https://ci.appveyor.com/)

Reference project: https://github.com/mapbox/node-sqlite3

**Warning** because CI fixing tends to produce a lot of commits, I will heavily `git commit --amend && git push --force` to keep the history clean. Don't pull without asking unless you want infinite merge hell. You have been warned.