### PR TITLE
Update nan for io.js 2.x.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 , "os": [ "darwin", "linux", "win32" ]
 , "dependencies" :
   { "bindings" : "1.1.x"
-  , "nan" : "1.5.x"
+  , "nan" : "^1.8"
   }
 , "engines" :
   { "node" : ">= 0.8.x"


### PR DESCRIPTION
Referencing iojs/io.js#1620

Note: this PR does not address the usage of deprecated nan features causing compiler warnings. This just allows installation and compilation with io.js v2.x.x