### PR TITLE
Update nan package dependency to 1.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 , "os": [ "darwin", "linux", "win32" ]
 , "dependencies" :
   { "bindings" : "1.1.x"
-  , "nan" : "1.5.x"
+  , "nan" : "1.8.x"
   }
 , "engines" :
   { "node" : ">= 0.8.x"


### PR DESCRIPTION
Updating the nan module dependency fixes iojs v2.0.1 compile issues on OSX and perhaps others.