### PR TITLE
FIX osx: NanUndefined() return bad handle

### DIFF
--- a/src/osx/BTSerialPortBinding.mm
+++ b/src/osx/BTSerialPortBinding.mm
@@ -186,7 +186,11 @@ void BTSerialPortBinding::EIO_AfterRead(uv_work_t *req) {
         Local<Object> resultBuffer = bufferConstructor->NewInstance(1, constructorArgs);
         memcpy(Buffer::Data(resultBuffer), baton->result, baton->size);
 
-        argv[0] = NanUndefined();
+        /* XXX workaround bad handle returned by NanUndefined()
+         * see issue #74 for detailed traces
+         * https://github.com/eelcocramer/node-bluetooth-serial-port/issues/74
+         */
+        argv[0] = NanNew(false);
         argv[1] = NanEscapeScope(resultBuffer);
     }
 


### PR DESCRIPTION
Related issue #74.
I don't know if it's the only error in the code, but I am sure this change fix an error.

With the original line (`argv[0] = NanUndefined()`) and asserts activated I got:
```
2015-06-24 15:29:15.286 node_g[54066:507] [static void BTSerialPortBinding::EIO_AfterRead(uv_work_t *):221] baton->size=74
2015-06-24 15:29:15.286 node_g[54066:507] [static void BTSerialPortBinding::EIO_AfterRead(uv_work_t *):224] memcpy OK
2015-06-24 15:29:15.287 node_g[54066:507] [static void BTSerialPortBinding::EIO_AfterRead(uv_work_t *):228] arguments OK


#
# Fatal error in ../deps/v8/src/handles-inl.h, line 65
# CHECK(reinterpret_cast<Address>(*location_) != kHandleZapValue) failed
#


==== Stack trace ============================================

Security context: 0x30774ea57281 <JS Object>#0#
    1: /* anonymous */ [/Users/thomas/Documents/projects/js/feetme/node_modules/bluetooth-serial-port/lib/bluetooth-serial-port.js:76] (this=0x30774ea573a1 <JS Global Object>#1#,err=Failure(0x6eb77ab42eb77ab),buffer=0x95bc7f80321 <a Buffer>#2#)

==== Details ================================================

[1]: /* anonymous */ [/Users/thomas/Documents/projects/js/feetme/node_modules/bluetooth-serial-port/lib/bluetooth-serial-port.js:76] (this=0x30774ea573a1 <JS Global Object>#1#,err=Failure(0x6eb77ab42eb77ab),buffer=0x95bc7f80321 <a Buffer>#2#) {
  // expression stack (top to bottom)
  [02] : 0
  [01] : 0
  [00] : Failure(0x6eb77ab42eb77ab)
--------- s o u r c e   c o d e ---------
function (err, buffer) {
        if (!err && buffer) { ...
-----------------------------------------
}

==== Key         ============================================

 #0# 0x30774ea57281: 0x30774ea57281 <JS Object>
 #1# 0x30774ea573a1: 0x30774ea573a1 <JS Global Object>
 #2# 0x95bc7f80321: 0x95bc7f80321 <a Buffer>
            length: 74
            parent: 0x15cea2f51e89 <a SlowBuffer>#3#
            offset: 7592
 #3# 0x15cea2f51e89: 0x15cea2f51e89 <a SlowBuffer>
            length: 8192
              used: 7672
=====================
```

With the fix recommended [here](https://github.com/nodejs/nan/issues/287#issuecomment-88388295) which gave `argv[0] = NanEscapeScope(NanUndefined())` and asserts activated I got:
```
[ '[WRITE]', { type: 'state', state: 'SENDING' } ]
2015-06-24 16:10:08.490 node_g[56396:507] [static void BTSerialPortBinding::EIO_AfterRead(uv_work_t *):221] baton->size=45
2015-06-24 16:10:08.490 node_g[56396:507] [static void BTSerialPortBinding::EIO_AfterRead(uv_work_t *):224] memcpy OK
FATAL ERROR: v8::HandleScope::Close() Local scope has already been closed
```

Same error with anything put inside `NanEscapeScope()`, which is understandable.

So this is a workaround, this is not canonic, but it works.