### PR TITLE
[osx] Reception buffer should be char, not int

### DIFF
--- a/src/osx/BTSerialPortBinding.mm
+++ b/src/osx/BTSerialPortBinding.mm
@@ -146,7 +146,7 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
 }
 
 void BTSerialPortBinding::EIO_Read(uv_work_t *req) {
-    unsigned int buf[1024] = { 0 };
+    unsigned char buf[1024] = { 0 };
 
     read_baton_t *baton = static_cast<read_baton_t *>(req->data);
     size_t size = 0;


### PR DESCRIPTION
`read_baton_t->result`  is an `unsigned char[1024]` ([definition](https://github.com/eelcocramer/node-bluetooth-serial-port/blob/master/src/BTSerialPortBinding.h#L63)), so [this memcpy](https://github.com/eelcocramer/node-bluetooth-serial-port/blob/master/src/osx/BTSerialPortBinding.mm#L167) makes a buffer overflow.

This PR fix the buffer type and close #76 (tested on my side with pipe filled with a lot of data).