### PR TITLE
remove 'data' event listener after connection lost

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Emitted when reading from the serial port connection results in an error. The co
 
 ## Typescript support
 Declaration file is bundled with code so you can use it without npm install @types/bluetooth-serial-port
-
+```typescript
 import btSerial = require("bluetooth-serial-port");
 
 btSerial.findSerialPortChannel(address: string, (channel: number) => {
@@ -267,7 +267,7 @@ btSerial.findSerialPortChannel(address: string, (channel: number) => {
 }, () => {
 	console.error("Cannot find channel!");
 });
-
+```
 ## LICENSE
 
 This module is available under a [FreeBSD license](http://opensource.org/licenses/BSD-2-Clause), see the [LICENSE file](https://github.com/eelcocramer/node-bluetooth-serial-port/blob/master/LICENSE.md) for details.

--- a/README.md
+++ b/README.md
@@ -252,20 +252,20 @@ Declaration file is bundled with code so you can use it without npm install @typ
 import btSerial = require("bluetooth-serial-port");
 
 btSerial.findSerialPortChannel(address: string, (channel: number) => {
-	btSerial.connect(address: string, channel: number, () => {
-		btSerial.write(new Buffer("yes"), (err) => {
-			if (err) {
-				console.error(err);
-			}
-		});
-	}, (err?: Error) => {
-		if (err) {
-			console.error(err);
-		}
-	});
-	btSerial.on("data", (buffer: Buffer) => console.log(buffer.toString("ascii")));
+    btSerial.connect(address: string, channel: number, () => {
+        btSerial.write(new Buffer("yes"), (err) => {
+	    if (err) {
+                console.error(err);
+            }
+        });
+    }, (err?: Error) => {
+            if (err) {
+                console.error(err);
+            }
+        });
+        btSerial.on("data", (buffer: Buffer) => console.log(buffer.toString("ascii")));
 }, () => {
-	console.error("Cannot find channel!");
+        console.error("Cannot find channel!");
 });
 ```
 ## LICENSE

--- a/README.md
+++ b/README.md
@@ -246,6 +246,28 @@ Emitted when reading from the serial port connection results in an error. The co
 
 * err - an [Error object](http://docs.nodejitsu.com/articles/errors/what-is-the-error-object) describing the failure.
 
+## Typescript support
+Declaration file is bundled with code so you can use it without npm install @types/bluetooth-serial-port
+
+import btSerial = require("bluetooth-serial-port");
+
+btSerial.findSerialPortChannel(address: string, (channel: number) => {
+	btSerial.connect(address: string, channel: number, () => {
+		btSerial.write(new Buffer("yes"), (err) => {
+			if (err) {
+				console.error(err);
+			}
+		});
+	}, (err?: Error) => {
+		if (err) {
+			console.error(err);
+		}
+	});
+	btSerial.on("data", (buffer: Buffer) => console.log(buffer.toString("ascii")));
+}, () => {
+	console.error("Cannot find channel!");
+});
+
 ## LICENSE
 
 This module is available under a [FreeBSD license](http://opensource.org/licenses/BSD-2-Clause), see the [LICENSE file](https://github.com/eelcocramer/node-bluetooth-serial-port/blob/master/LICENSE.md) for details.

--- a/lib/bluetooth-serial-port.d.ts
+++ b/lib/bluetooth-serial-port.d.ts
@@ -1,0 +1,39 @@
+// Type definitions for bluetooth-serial-port v2.1.0
+// Project: https://github.com/eelcocramer/node-bluetooth-serial-port
+// Definitions by: Sand Angel <https://github.com/sandangel, DefinitelyTyped
+// <https://github.com/DefinitelyTyped/DefinitelyTyped>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+/// <reference types="node" />
+
+import EventEmitter = require('events');
+
+declare module BluetoothSerialPort {
+  class BluetoothSerialPort extends EventEmitter {
+    constructor();
+    inquire(): void;
+    inquireSync(): void;
+    findSerialPortChannel(
+        address: string, successCallback: (channel: number) => void,
+        errorCallback?: () => void): void;
+    connect(
+        address: string, channel: number, successCallback: () => void,
+        errorCallback?: (err?: Error) => void): void;
+    write(buffer: Buffer, cb: (err?: Error) => void): void;
+    close(): void;
+    isOpen(): boolean;
+    listPairedDevices(): void;
+  }
+  class BluetoothSerialPortServer {
+    constructor();
+    listen(
+        successCallback: (clientAddress: string) => void,
+        errorCallback?: (err: any) => void,
+        options?: {uuid?: string; channel: number;}): void;
+    write(buffer: Buffer, callback: (err?: Error) => void): void;
+    close(): void;
+    isOpen(): boolean;
+  }
+}
+
+export = BluetoothSerialPort;

--- a/lib/bluetooth-serial-port.js
+++ b/lib/bluetooth-serial-port.js
@@ -75,12 +75,22 @@
                             if (!err && buffer) {
                                 self.emit('data', buffer);
                             } else {
-                                self.close();
-                                self.emit('failure', err);
+                                self.removeListener('data', dataListener);  // remove it to prevent
+                                self.close();                               // calling self.on many
+                                self.emit('failure', err);                  // times
                             }
                         });
                     }
                 });
+            },
+            dataListener = function (buffer) { // event listenner
+                if (buffer.length <= 0) {
+                        // we are done reading. The remote device might have closed the device
+                        // or we have closed it ourself. Lets cleanup our side anyway...
+                        self.close();
+                    } else {
+                        read();
+                    }
             },
             connection = new btSerial.BTSerialPortBinding(address, channel, function () {
                 self.address = address;
@@ -88,15 +98,7 @@
                 self.connection = connection;
                 self.isReading = false;
 
-                self.on('data', function (buffer) {
-                    if (buffer.length <= 0) {
-                        // we are done reading. The remote device might have closed the device
-                        // or we have closed it ourself. Lets cleanup our side anyway...
-                        self.close();
-                    } else {
-                        read();
-                    }
-                });
+                self.on('data', dataListener); // add listener to event 'data'
 
                 read();
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lib": "./lib"
   },
   "main": "./lib/bluetooth-serial-port.js",
+  "types": "./lib/bluetooth-serial-port.d.ts",
   "os": [
     "darwin",
     "linux",
@@ -29,6 +30,9 @@
   "dependencies": {
     "bindings": "1.2.x",
     "nan": "latest"
+  },
+  "optionalDependencies": {
+    "@types/node": "^7.0.10"
   },
   "engines": {
     "node": ">= 0.8.x",


### PR DESCRIPTION
When a device lost connection, you will want to reconnect it from the instance you have created (if you create another instance, it will lead to memory leak in case you try reconnecting repeatedly).  if the connection success, it will add another 'data' event listener to that BluetoothSerialPort instance and lead to connection read error. So just remove it after connection lost.