### PR TITLE
Promise, async/await syntax and fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,8 @@ Emitted when reading from the serial port connection results in an error. The co
 The type script declaration file is bundled with this module so you can use it without needing to `npm install @types/bluetooth-serial-port`
 
 ```typescript
-import btSerial = require("bluetooth-serial-port");
+import BluetoothSerialPort = require("bluetooth-serial-port");
+const btSerial = new BluetoothSerialPort();
 
 btSerial.findSerialPortChannel(address: string, (channel: number) => {
     btSerial.connect(address: string, channel: number, () => {
@@ -270,6 +271,47 @@ btSerial.findSerialPortChannel(address: string, (channel: number) => {
 });
 ```
 
+## Promise syntax sugar
+
+Add new ES6 feature: Promise, use the fastest promise library Bluebird. This feature also has Typescript support.
+
+# Javascript:
+
+```javascript
+var btSerial = new (require('bluetooth-serial-port')).BluetoothSerialPort();
+
+btSerial.findSerialPortChannelAsync(address).then(function (channel) {
+    return btSerial.connectAsync(address, channel); // must have return
+}).then(function() {
+    btSerial.on("data", function (buffer) {
+        console.log(buffer.toString("utf8"));
+    });
+}).catch(function(err){
+    console.error(err);
+});
+
+```
+# Typescript
+
+This example is written with async/await function:
+
+``` typescript
+import BluetoothSerialPort = require("bluetooth-serial-port");
+const btSerial = new BluetoothSerialPort();
+
+btSerial.on("found", async(address: string, name: string) => {
+    try {
+        const channel = await btSerial.findSerialPortChannelAsync(address);
+        await btSerial.connectAsync(address, channel);
+        btSerial.on("data", (buffer) => {
+            console.log(buffer.toString("ascii"));
+        });
+    } catch (e) {
+        console.error(e);
+    }    
+});
+
+```
 ## LICENSE
 
 This module is available under a [FreeBSD license](http://opensource.org/licenses/BSD-2-Clause), see the [LICENSE file](https://github.com/eelcocramer/node-bluetooth-serial-port/blob/master/LICENSE.md) for details.

--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ Emitted when reading from the serial port connection results in an error. The co
 The type script declaration file is bundled with this module so you can use it without needing to `npm install @types/bluetooth-serial-port`
 
 ```typescript
-import BluetoothSerialPort = require("bluetooth-serial-port");
-const btSerial = new BluetoothSerialPort();
+import Bluetooth = require("bluetooth-serial-port");
+const btSerial = new Bluetooth.BluetoothSerialPort();
 
 btSerial.findSerialPortChannel(address: string, (channel: number) => {
     btSerial.connect(address: string, channel: number, () => {
@@ -275,41 +275,47 @@ btSerial.findSerialPortChannel(address: string, (channel: number) => {
 
 Add new ES6 feature: Promise, use the fastest promise library Bluebird. This feature also has Typescript support.
 
-# Javascript:
+### Javascript:
 
 ```javascript
+'use strict';
 var btSerial = new (require('bluetooth-serial-port')).BluetoothSerialPort();
 
-btSerial.findSerialPortChannelAsync(address).then(function (channel) {
-    return btSerial.connectAsync(address, channel); // must have return
-}).then(function() {
-    btSerial.on("data", function (buffer) {
-        console.log(buffer.toString("utf8"));
-    });
-}).catch(function(err){
-    console.error(err);
+btSerial.on('found', function(address, name) {
+  btSerial.findSerialPortChannelAsync(address)
+      .then(function(channel) {
+        return btSerial.connectAsync(address, channel);  // must have return
+      })
+      .then(function() {
+        btSerial.on(
+            'data', function(buffer) { console.log(buffer.toString('utf8')); });
+      })
+      .catch(function(err) { console.error(err); });
 });
 
+btSerial.inquire();
+
 ```
-# Typescript
+### Typescript
 
 This example is written with async/await function:
 
 ``` typescript
-import BluetoothSerialPort = require("bluetooth-serial-port");
-const btSerial = new BluetoothSerialPort();
+import Bluetooth = require("bluetooth-serial-port");
+const btSerial = new Bluetooth.BluetoothSerialPort();
 
 btSerial.on("found", async(address: string, name: string) => {
-    try {
-        const channel = await btSerial.findSerialPortChannelAsync(address);
-        await btSerial.connectAsync(address, channel);
-        btSerial.on("data", (buffer) => {
-            console.log(buffer.toString("ascii"));
-        });
-    } catch (e) {
-        console.error(e);
-    }    
+  try {
+    const channel = await btSerial.findSerialPortChannelAsync(address);
+    await btSerial.connectAsync(address, channel);
+    btSerial.on(
+        "data", (buffer: Buffer) => { console.log(buffer.toString("ascii")); });
+  } catch (e) {
+    console.error(e);
+  }
 });
+
+btSerial.inquire();
 
 ```
 ## LICENSE

--- a/lib/bluetooth-serial-port.d.ts
+++ b/lib/bluetooth-serial-port.d.ts
@@ -5,8 +5,9 @@
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="node" />
-
 import EventEmitter = require("events");
+
+/// <reference types="bluebird" />
 import Bluebird = require("bluebird")
 
 declare module BluetoothSerialPort {

--- a/lib/bluetooth-serial-port.d.ts
+++ b/lib/bluetooth-serial-port.d.ts
@@ -6,7 +6,8 @@
 
 /// <reference types="node" />
 
-import EventEmitter = require('events');
+import EventEmitter = require("events");
+import Bluebird = require("bluebird")
 
 declare module BluetoothSerialPort {
   class BluetoothSerialPort extends EventEmitter {
@@ -23,6 +24,8 @@ declare module BluetoothSerialPort {
     close(): void;
     isOpen(): boolean;
     listPairedDevices(): void;
+    findSerialPortChannelAsync(address: string): Bluebird<number>;
+    connectAsync(address: string, channel: number): Bluebird<void>; 
   }
   class BluetoothSerialPortServer {
     constructor();

--- a/lib/bluetooth-serial-port.js
+++ b/lib/bluetooth-serial-port.js
@@ -18,8 +18,7 @@
     var util = require('util'),
         EventEmitter = require('events').EventEmitter,
         btSerial = require('bindings')('BluetoothSerialPort.node'),
-        DeviceINQ = require("./device-inquiry.js").DeviceINQ,
-        Promise = require("bluebird");
+        DeviceINQ = require("./device-inquiry.js").DeviceINQ;
 
     /**
      * Creates an instance of the bluetooth-serial object.
@@ -57,17 +56,17 @@
         this.inq.inquireSync(this.found, this.finish);
     };
 
-    BluetoothSerialPort.prototype.findSerialPortChannel = function (address, successCallback, errorCallback) {
+    BluetoothSerialPort.prototype.findSerialPortChannel = function (address, callback) {
         this.inq.findSerialPortChannel(address, function (channel) {
             if (channel >= 0) {
-                successCallback(channel);
-            } else if (errorCallback) {
-                errorCallback();
+                callback(null, channel);
+            } else {
+                callback(new Error("Failed to find channel!"));
             }
         });
     };
 
-    BluetoothSerialPort.prototype.connect = function (address, channel, successCallback, errorCallback) {
+    BluetoothSerialPort.prototype.connect = function (address, channel, callback) {
         var self = this,
             read = function () {
                 process.nextTick(function () {
@@ -103,7 +102,7 @@
 
                 read();
 
-                successCallback();
+                callback();
             }, function (err) {
                 // cleaning up the the failed connection
                 if (connection) {
@@ -111,17 +110,17 @@
                 }
 
                 if (errorCallback) {
-                    errorCallback(err);
+                    callback(err);
                 }
             });
     };
 
-    BluetoothSerialPort.prototype.write = function (buffer, cb) {
+    BluetoothSerialPort.prototype.write = function (buffer, callback) {
         if (this.connection) {
-            this.connection.write(buffer, this.address, cb);
+            this.connection.write(buffer, this.address, callback);
         } else {
             var err = new Error("Not connected");
-            cb.call(err);
+            callback.call(err);
         }
     };
 
@@ -137,20 +136,6 @@
     BluetoothSerialPort.prototype.isOpen = function () {
         return this.connection !== undefined;
     };
-
-    BluetoothSerialPort.prototype.findSerialPortChannelAsync = function (address) {
-        var self = this;
-        return new Promise(function (resolve, reject) {
-            self.findSerialPortChannel(address, resolve, reject);
-        });
-    };
-
-    BluetoothSerialPort.prototype.connectAsync = function (address, channel) {
-        var self = this;
-        return new Promise(function (resolve, reject) {
-            self.connect(address, channel, resolve, reject);
-        });
-    }
 }());
 
 (function () {
@@ -163,7 +148,6 @@
     var util = require('util'),
         EventEmitter = require('events').EventEmitter,
         btSerial = require('bindings')('BluetoothSerialPortServer.node'),
-        Promise = require("bluebird"),
         _SERIAL_PORT_PROFILE_UUID = '1101',
         _DEFAULT_SERVER_CHANNEL = 1,
         _ERROR_CLIENT_CLOSED_CONNECTION = 'Error: Connection closed by the client';

--- a/lib/bluetooth-serial-port.js
+++ b/lib/bluetooth-serial-port.js
@@ -106,7 +106,9 @@
                 successCallback();
             }, function (err) {
                 // cleaning up the the failed connection
-                connection.close(address);
+                if (connection) {
+                    connection.close(address);
+                }
 
                 if (errorCallback) {
                     errorCallback(err);

--- a/lib/bluetooth-serial-port.js
+++ b/lib/bluetooth-serial-port.js
@@ -109,7 +109,7 @@
                     connection.close(address);
                 }
 
-                if (errorCallback) {
+                if (callback) {
                     callback(err);
                 }
             });

--- a/lib/bluetooth-serial-port.js
+++ b/lib/bluetooth-serial-port.js
@@ -18,7 +18,8 @@
     var util = require('util'),
         EventEmitter = require('events').EventEmitter,
         btSerial = require('bindings')('BluetoothSerialPort.node'),
-        DeviceINQ = require("./device-inquiry.js").DeviceINQ;
+        DeviceINQ = require("./device-inquiry.js").DeviceINQ,
+        Promise = require("bluebird");
 
     /**
      * Creates an instance of the bluetooth-serial object.
@@ -134,6 +135,20 @@
     BluetoothSerialPort.prototype.isOpen = function () {
         return this.connection !== undefined;
     };
+
+    BluetoothSerialPort.prototype.findSerialPortChannelAsync = function (address) {
+        var self = this;
+        return new Promise(function (resolve, reject) {
+            self.findSerialPortChannel(address, resolve, reject);
+        });
+    };
+
+    BluetoothSerialPort.prototype.connectAsync = function (address, channel) {
+        var self = this;
+        return new Promise(function (resolve, reject) {
+            self.connect(address, channel, resolve, reject);
+        });
+    }
 }());
 
 (function () {
@@ -146,6 +161,7 @@
     var util = require('util'),
         EventEmitter = require('events').EventEmitter,
         btSerial = require('bindings')('BluetoothSerialPortServer.node'),
+        Promise = require("bluebird"),
         _SERIAL_PORT_PROFILE_UUID = '1101',
         _DEFAULT_SERVER_CHANNEL = 1,
         _ERROR_CLIENT_CLOSED_CONNECTION = 'Error: Connection closed by the client';

--- a/package.json
+++ b/package.json
@@ -29,11 +29,9 @@
   ],
   "dependencies": {
     "bindings": "1.2.x",
-    "bluebird": "^3.5.0",
     "nan": "latest"
   },
   "optionalDependencies": {
-    "@types/bluebird": "^3.5.2",
     "@types/node": "^7.0.10"
   },
   "engines": {
@@ -57,5 +55,8 @@
     "Juan Gomez",
     "Eric Lundby",
     "Kevin Clarens"
-  ]
+  ],
+  "devDependencies": {
+    "typescript": "^2.2.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "bindings": "1.2.x",
     "nan": "latest"
   },
-  "optionalDependencies": {
-    "@types/node": "^7.0.10"
-  },
   "engines": {
     "node": ">= 0.12.x",
     "npm": ">= 1.1.x"
@@ -55,8 +52,5 @@
     "Juan Gomez",
     "Eric Lundby",
     "Kevin Clarens"
-  ],
-  "devDependencies": {
-    "typescript": "^2.2.2"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -29,9 +29,11 @@
   ],
   "dependencies": {
     "bindings": "1.2.x",
+    "bluebird": "^3.5.0",
     "nan": "latest"
   },
   "optionalDependencies": {
+    "@types/bluebird": "^3.5.2",
     "@types/node": "^7.0.10"
   },
   "engines": {


### PR DESCRIPTION
1. Fix a mistake with example in README.
2. Add promise support with bluebird.
3. Add types declaration for async function.
4. Fix bug:
There is an error TypeError: Cannot read property 'close' of undefined when you try to call function btSerial.connect before findSerialPortChannel.  
Step to reproduce:
btSerial.connect(address, 3, function(){}, function(){}) //you give channel a default value.
