### PR TITLE
Finish the job of listPairedDevices for windows

### DIFF
--- a/examples/paired.js
+++ b/examples/paired.js
@@ -1,0 +1,5 @@
+const BluetoothSerialPort = require('../lib/bluetooth-serial-port');
+const rfcomm = new BluetoothSerialPort.BluetoothSerialPort();
+rfcomm.listPairedDevices(function (list) {
+		console.log(JSON.stringify(list,null,2));
+});


### PR DESCRIPTION
The structure contain all real service name and port.
Using listPairedDevices on mac and now on windows let us choose the service we want to connect.