### PR TITLE
Add method "on" to TypeScript declaration file

### DIFF
--- a/lib/bluetooth-serial-port.d.ts
+++ b/lib/bluetooth-serial-port.d.ts
@@ -30,6 +30,7 @@ declare module BluetoothSerialPort {
         successCallback: (clientAddress: string) => void,
         errorCallback?: (err: any) => void,
         options?: {uuid?: string; channel: number;}): void;
+    on(event: string, callback: (arg1:any, arg2:any) => void): void;
     write(buffer: Buffer, callback: (err?: Error) => void): void;
     close(): void;
     isOpen(): boolean;


### PR DESCRIPTION
Hi,

the new TS-declaration-file in version 2.1.3 is missing the "on" method to register events.
Without this the transpiler complains about a missing method.
This PR adds a method declaration that is working fine for my use case.
I wasn't sure, how to properly name the callback args, because their meaning depends on the event. So I ended up with the general names arg1 and arg2. I hope this ok, feel free to change the names :)

Best wishes