### PR TITLE
Call shutdown() before close() to insure bluetooth disconnects

### DIFF
--- a/src/linux/BTSerialPortBinding.cc
+++ b/src/linux/BTSerialPortBinding.cc
@@ -349,6 +349,7 @@ NAN_METHOD(BTSerialPortBinding::Close) {
     BTSerialPortBinding* rfcomm = Nan::ObjectWrap::Unwrap<BTSerialPortBinding>(info.This());
 
     if (rfcomm->s != 0) {
+        shutdown(rfcomm->s, SHUT_RDWR);
         close(rfcomm->s);
         write(rfcomm->rep[1], "close", (strlen("close")+1));
         rfcomm->s = 0;


### PR DESCRIPTION
This is related to #162.
Calling shutdown() before close() seems to help insure that the actual bluetooth connection underlying the socket is disconnected when closing the socket.  This is for linux implementation only.
Tested on Raspberry Pi Stretch.