### PR TITLE
Return the number of bytes successfully written even if there is an error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Check whether the connection is open or not.
 Writes a [Buffer](http://nodejs.org/api/buffer.html) to the serial port connection.
 
 * buffer - the [Buffer](http://nodejs.org/api/buffer.html) to be written.
-* callback(err, bytesWritten) - is called when the write action has been completed. When the `err` parameter is set an error has occured, in that case `err` is an [Error object](http://docs.nodejitsu.com/articles/errors/what-is-the-error-object). When `err` is not set the write action was successful and `bytesWritten` contains the amount of bytes that is written to the connection.
+* callback(err, bytesWritten) - is called when the write action has been completed. When the `err` parameter is set an error has occured, in that case `err` is an [Error object](http://docs.nodejitsu.com/articles/errors/what-is-the-error-object). When `err` is not set the write action was successful (all bytes were written.) 'bytesWritten' is always the number of bytes successfully written (so that the caller may retry if not all bytes were sent) or -1 if no bytes were successfully written. 'err' is populated if the write was only partially successful, and 'bytes' is populated with the number of bytes written.
 
 #### BluetoothSerialPort.listPairedDevices(callback)
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Check whether the connection is open or not.
 Writes a [Buffer](http://nodejs.org/api/buffer.html) to the serial port connection.
 
 * buffer - the [Buffer](http://nodejs.org/api/buffer.html) to be written.
-* callback(err, bytesWritten) - is called when the write action has been completed. When the `err` parameter is set an error has occured, in that case `err` is an [Error object](http://docs.nodejitsu.com/articles/errors/what-is-the-error-object). When `err` is not set the write action was successful (all bytes were written.) 'bytesWritten' is always the number of bytes successfully written (so that the caller may retry if not all bytes were sent) or -1 if no bytes were successfully written. 'err' is populated if the write was only partially successful, and 'bytes' is populated with the number of bytes written.
+* callback(err, bytesWritten) - is called when the write action has been completed. When the `err` parameter is set an error has occured, in that case `err` is an [Error object](http://docs.nodejitsu.com/articles/errors/what-is-the-error-object). When `err` is not set some or all bytes were written. 'bytesWritten' is always the number of bytes successfully written (so that the caller may retry if not all bytes were sent) or 0 if no bytes were successfully written.
 
 #### BluetoothSerialPort.listPairedDevices(callback)
 

--- a/src/linux/BTSerialPortBinding.cc
+++ b/src/linux/BTSerialPortBinding.cc
@@ -111,13 +111,10 @@ void BTSerialPortBinding::EIO_Write(uv_work_t *req) {
     }
 
     data->result = write(rfcomm->s, data->bufferData, data->bufferLength);
-
-    if (data-> result == -1) {
-        sprintf(data->errorString, "No bytes were successfully sent.");
+    
+    if (data->result != data->bufferLength) {
+        sprintf(data->errorString, "Writing attempt was not completely successful");
     }
-    else if (data->result != data->bufferLength) {
-        sprintf(data->errorString, "Writing attempt was partially successful.");
-    } 
 }
 
 void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {

--- a/src/linux/BTSerialPortBinding.cc
+++ b/src/linux/BTSerialPortBinding.cc
@@ -112,8 +112,8 @@ void BTSerialPortBinding::EIO_Write(uv_work_t *req) {
 
     data->result = write(rfcomm->s, data->bufferData, data->bufferLength);
     
-    if (data->result != data->bufferLength) {
-        sprintf(data->errorString, "Writing attempt was not completely successful");
+    if (data->result < 0) {
+        sprintf(data->errorString, "Could not write any bytes");
     }
 }
 
@@ -123,16 +123,16 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
     queued_write_t *queuedWrite = static_cast<queued_write_t*>(req->data);
     write_baton_t *data = static_cast<write_baton_t*>(queuedWrite->baton);
 
+    int32_t bytesWritten = (int32_t)data->result < 0 ? 0 : (int32_t)data->result;
+
     Local<Value> argv[2];
     if (data->errorString[0]) {
         argv[0] = Nan::Error(data->errorString);
 
-        // Still return the number of bytes written so that the caller can retry to
-        // write the rest. -1 if no bytes were successfully written
-        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
+        argv[1] = Nan::New<v8::Integer>(bytesWritten);
     } else {
         argv[0] = Nan::Undefined();
-        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
+        argv[1] = Nan::New<v8::Integer>(bytesWritten);
     }
 
     data->callback->Call(2, argv);

--- a/src/linux/BTSerialPortBinding.cc
+++ b/src/linux/BTSerialPortBinding.cc
@@ -131,7 +131,7 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
         argv[0] = Nan::Error(data->errorString);
 
         // Still return the number of bytes written so that the caller can retry to
-        // write the rest
+        // write the rest. -1 if no bytes were successfully written
         argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
     } else {
         argv[0] = Nan::Undefined();

--- a/src/linux/BTSerialPortBinding.cc
+++ b/src/linux/BTSerialPortBinding.cc
@@ -123,16 +123,13 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
     queued_write_t *queuedWrite = static_cast<queued_write_t*>(req->data);
     write_baton_t *data = static_cast<write_baton_t*>(queuedWrite->baton);
 
-    int32_t bytesWritten = (int32_t)data->result < 0 ? 0 : (int32_t)data->result;
-
     Local<Value> argv[2];
     if (data->errorString[0]) {
         argv[0] = Nan::Error(data->errorString);
-
-        argv[1] = Nan::New<v8::Integer>(bytesWritten);
+        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
     } else {
         argv[0] = Nan::Undefined();
-        argv[1] = Nan::New<v8::Integer>(bytesWritten);
+        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
     }
 
     data->callback->Call(2, argv);

--- a/src/osx/BTSerialPortBinding.mm
+++ b/src/osx/BTSerialPortBinding.mm
@@ -119,16 +119,16 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
     queued_write_t *queuedWrite = static_cast<queued_write_t*>(req->data);
     write_baton_t *data = static_cast<write_baton_t*>(queuedWrite->baton);
 
+    int32_t bytesWritten = (int32_t)data->result < 0 ? 0 : (int32_t)data->result;
+
     Local<Value> argv[2];
     if (data->errorString[0]) {
         argv[0] = Nan::Error(data->errorString);
 
-        // Still return the number of bytes written so that the caller can retry to
-        // write the rest. -1 if no bytes were successfully written
-        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
+        argv[1] = Nan::New<v8::Integer>(bytesWritten);
     } else {
         argv[0] = Nan::Undefined();
-        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
+        argv[1] = Nan::New<v8::Integer>(bytesWritten);
     }
 
     data->callback->Call(2, argv);

--- a/src/osx/BTSerialPortBinding.mm
+++ b/src/osx/BTSerialPortBinding.mm
@@ -119,16 +119,13 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
     queued_write_t *queuedWrite = static_cast<queued_write_t*>(req->data);
     write_baton_t *data = static_cast<write_baton_t*>(queuedWrite->baton);
 
-    int32_t bytesWritten = (int32_t)data->result < 0 ? 0 : (int32_t)data->result;
-
     Local<Value> argv[2];
     if (data->errorString[0]) {
         argv[0] = Nan::Error(data->errorString);
-
-        argv[1] = Nan::New<v8::Integer>(bytesWritten);
+        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
     } else {
         argv[0] = Nan::Undefined();
-        argv[1] = Nan::New<v8::Integer>(bytesWritten);
+        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
     }
 
     data->callback->Call(2, argv);

--- a/src/osx/BTSerialPortBinding.mm
+++ b/src/osx/BTSerialPortBinding.mm
@@ -122,7 +122,10 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
     Local<Value> argv[2];
     if (data->errorString[0]) {
         argv[0] = Nan::Error(data->errorString);
-        argv[1] = Nan::Undefined();
+
+        // Still return the number of bytes written so that the caller can retry to
+        // write the rest. -1 if no bytes were successfully written
+        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
     } else {
         argv[0] = Nan::Undefined();
         argv[1] = Nan::New<v8::Integer>((int32_t)data->result);

--- a/src/windows/BTSerialPortBinding.cc
+++ b/src/windows/BTSerialPortBinding.cc
@@ -113,18 +113,13 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
     queued_write_t *queuedWrite = static_cast<queued_write_t*>(req->data);
     write_baton_t *data = static_cast<write_baton_t*>(queuedWrite->baton);
 
-    int32_t bytesWritten = (int32_t)data->result < 0 ? 0 : (int32_t)data->result;
-
     Local<Value> argv[2];
     if (data->errorString[0]) {
         argv[0] = Nan::Error(data->errorString);
-
-        // Still return the number of bytes written so that the caller can retry to
-        // write the rest. -1 if no bytes were successfully written
-        argv[1] = Nan::New<v8::Integer>(bytesWritten);
+        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
     } else {
         argv[0] = Nan::Undefined();
-        argv[1] = Nan::New<v8::Integer>(bytesWritten);
+        argv[1] = Nan::New<v8::Integer>((int32_t)data->result);
     }
 
     data->callback->Call(2, argv);

--- a/src/windows/BTSerialPortBinding.cc
+++ b/src/windows/BTSerialPortBinding.cc
@@ -113,16 +113,18 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
     queued_write_t *queuedWrite = static_cast<queued_write_t*>(req->data);
     write_baton_t *data = static_cast<write_baton_t*>(queuedWrite->baton);
 
+    int32_t bytesWritten = (int32_t)data->result < 0 ? 0 : (int32_t)data->result;
+
     Local<Value> argv[2];
     if (data->errorString[0]) {
         argv[0] = Nan::Error(data->errorString);
 
         // Still return the number of bytes written so that the caller can retry to
         // write the rest. -1 if no bytes were successfully written
-        argv[1] = Nan::New<v8::Integer>(static_cast<int32_t>(data->result));
+        argv[1] = Nan::New<v8::Integer>(bytesWritten);
     } else {
         argv[0] = Nan::Undefined();
-        argv[1] = Nan::New<v8::Integer>(static_cast<int32_t>(data->result));
+        argv[1] = Nan::New<v8::Integer>(bytesWritten);
     }
 
     data->callback->Call(2, argv);

--- a/src/windows/BTSerialPortBinding.cc
+++ b/src/windows/BTSerialPortBinding.cc
@@ -116,7 +116,10 @@ void BTSerialPortBinding::EIO_AfterWrite(uv_work_t *req) {
     Local<Value> argv[2];
     if (data->errorString[0]) {
         argv[0] = Nan::Error(data->errorString);
-        argv[1] = Nan::Undefined();
+
+        // Still return the number of bytes written so that the caller can retry to
+        // write the rest. -1 if no bytes were successfully written
+        argv[1] = Nan::New<v8::Integer>(static_cast<int32_t>(data->result));
     } else {
         argv[0] = Nan::Undefined();
         argv[1] = Nan::New<v8::Integer>(static_cast<int32_t>(data->result));


### PR DESCRIPTION
I'm using this library for a library that is quite write heavy. Sometimes, the `write` call only manages to send *some* of the bytes. 

As well as the error string, I'd like the number of bytes that were *successfully* written to be returned so that my application can retry to send the rest (but not repeat the bytes that *were* successfully written.)